### PR TITLE
Modifications on oscSender

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ First of all, you need to add an **OSCtransmitter** node in your scene. It is lo
 
 ![OSCtransmitter in creation menu](https://frankiezafe.org/images/7/7c/Godot_gdosc_OSCtransmitter.png)
 
-Once done, attach a script to it who looks like this:S
+Once done, attach a script to it who looks like this:
 
 ```python
 extends OSCtransmitter

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ func _on_osc_message(val):
 
 ### Sending messages
 
-First of all, you need to add an **OSCtransmitter** node in your scene. It is located in the firt level of the tree, between *HTTPRequest* and *ResourcePreloader*.
+First of all, you need to add an **OSCtransmitter** node in your scene. It is located in the first level of the tree, between *HTTPRequest* and *ResourcePreloader*.
 
 ![OSCtransmitter in creation menu](https://frankiezafe.org/images/7/7c/Godot_gdosc_OSCtransmitter.png)
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you wants to use clang, install it with:
 
 `sudo apt install clang`
 
-If you are using gcc, just skip *use_llvm=yes* and it will be ok.
+If you are using gcc, just skip the *use_llvm=yes* and it will be ok.
 
 #### git
 
@@ -108,7 +108,13 @@ func _on_osc_message(val):
             translate(Vector3(val[2], val[3], val[4]))
 ```
 
-And here's an approach for sending:
+### Sending messages
+
+First of all, you need to add an **OSCtransmitter** node in your scene. It is located in the **Spatial** subtree, between *NavigationMeshInstance* and *Path*.
+
+![OSCtransmitter in creation menu](https://frankiezafe.org/images/7/7c/Godot_gdosc_OSCtransmitter.png)
+
+Once done, attach a script to it who looks like this:
 
 ```python
 extends OSCtransmitter

--- a/README.md
+++ b/README.md
@@ -119,28 +119,24 @@ Once done, attach a script to it who looks like this:
 ```python
 extends OSCtransmitter
 
-var new_sender = OSCtransmitter.new()
-var parent
-
 signal exit()
 
 func _ready():
-    set_process(true)
-    parent = get_parent()
-	# set the destination address and port
-    new_sender.init("localhost", 9020)
+	set_process(true)
+	# initialisation of OSC sender, on port 25000 and with a buffer size of 1024
+	init("localhost", 25000, 1024)
+	framecount = 0
+	pass
 
 func _process(delta):
-	# build the message
-	# OSC address
-    new_sender.setAddress("/update")
-	# some other parameters that we want to include
-    new_sender.appendString(parent.get_name())
-    new_sender.appendFloat(parent.translation.x)
-    new_sender.appendFloat(parent.translation.y)
-    new_sender.appendFloat(parent.translation.z)
-	# actually send the message
-    new_sender.sendMessage()
-	# reset the queue
-    new_sender.reset()
+	# creation of the new message
+	setAddress("/update")
+	# appending data
+	appendInt(framecount)
+	# sending the message to the client
+	sendMessage()
+	# cleanup of the message
+	reset()
+	framecount += 1
+	pass
 ```

--- a/README.md
+++ b/README.md
@@ -110,11 +110,11 @@ func _on_osc_message(val):
 
 ### Sending messages
 
-First of all, you need to add an **OSCtransmitter** node in your scene. It is located in the **Spatial** subtree, between *NavigationMeshInstance* and *Path*.
+First of all, you need to add an **OSCtransmitter** node in your scene. It is located in the firt level of the tree, between *HTTPRequest* and *ResourcePreloader*.
 
 ![OSCtransmitter in creation menu](https://frankiezafe.org/images/7/7c/Godot_gdosc_OSCtransmitter.png)
 
-Once done, attach a script to it who looks like this:
+Once done, attach a script to it who looks like this:S
 
 ```python
 extends OSCtransmitter

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ First of all, you need to add an **OSCtransmitter** node in your scene. It is lo
 
 ![OSCtransmitter in creation menu](https://frankiezafe.org/images/7/7c/Godot_gdosc_OSCtransmitter.png)
 
-Once done, attach a script to it who looks like this:
+Once done, attach a script to it that looks like this:
 
 ```python
 extends OSCtransmitter

--- a/oscSender.cpp
+++ b/oscSender.cpp
@@ -1,66 +1,64 @@
 #include "oscSender.h"
 #include "osc/OscOutboundPacketStream.h"
 
-
-bool gdOscSender::init(std::string host, int port) {
-  settings.host = host;
-  settings.port = port;
-  return setup(settings);
+bool gdOscSender::init(std::string host, int port, int buffersize) {
+    settings.host = host;
+    settings.port = port;
+    settings.buffersize = buffersize;
+    return setup(settings);
 }
 
+bool gdOscSender::setup(gdOscSenderSettings &settings) {
+    UdpTransmitSocket *socket = nullptr;
+    this->settings = settings;
+    try {
+        IpEndpointName name = IpEndpointName(settings.host.c_str(), settings.port);
+        socket = new UdpTransmitSocket(name);
+        sendSocket.reset(socket);
+        std::cout << "socket should be reset now" << std::endl;
+    } catch (std::exception &e) {
+        std::cout << "failed creating sendSocket because: " << e.what() << std::endl;
+        sendSocket.reset();
+        return false;
+    }
+    return true;
+}
 
-bool gdOscSender::setup(gdOscSenderSettings &settings){
-  UdpTransmitSocket *socket = nullptr;
-  this->settings = settings;
-  try {
-    IpEndpointName name = IpEndpointName(settings.host.c_str(), settings.port);
-    socket = new UdpTransmitSocket(name);
-    sendSocket.reset(socket);
-    std::cout << "socket should be reset now" << std::endl;
-  }
-  catch(std::exception &e){
-    std::cout << "failed creating sendSocket because: "  << e.what() << std::endl;
+void gdOscSender::clear() {
     sendSocket.reset();
-    return false;
-  }
-  return true;
-}
-
-void gdOscSender::clear(){
-  sendSocket.reset();
 }
 
 void gdOscSender::sendMessage(gdOscMessage &message) {
-  if(!sendSocket){
-    std::cout << "trying to send with empty socket" << std::endl;
-		return;
-	}
+    if (!sendSocket) {
+        std::cout << "trying to send with empty socket" << std::endl;
+        return;
+    }
 
-	// setting this much larger as it gets trimmed down to the size its using before being sent.
-  // TODO: find a way to make it dynamic?
-	static const int OUTPUT_BUFFER_SIZE = 327680;
-	char buffer[OUTPUT_BUFFER_SIZE];
-	osc::OutboundPacketStream p(buffer, OUTPUT_BUFFER_SIZE);
+    // setting this much larger as it gets trimmed down to the size its using before being sent.
+    // TODO: find a way to make it dynamic?
+    // static const int OUTPUT_BUFFER_SIZE = 327680;
+    char buffer[settings.buffersize];
+    osc::OutboundPacketStream p(buffer, settings.buffersize);
 
-  p << ::osc::BeginBundleImmediate;
-	appendMessage(message, p);
-	p << ::osc::EndBundle;
+    p << ::osc::BeginBundleImmediate;
+    appendMessage(message, p);
+    p << ::osc::EndBundle;
 
-  sendSocket->Send(p.Data(), p.Size());
+    sendSocket->Send(p.Data(), p.Size());
 }
 
 void gdOscSender::appendMessage(gdOscMessage &message, osc::OutboundPacketStream &p) {
-  p << ::osc::BeginMessage(message.getAddress().c_str());
-	for (int i = 0; i < message.getNumArgs(); ++i) {
-		if (message.getArgType(i) == TYPE_INT32){
-			p << message.getArgAsInt32(i);
-		}else if (message.getArgType(i) == TYPE_FLOAT){
-			p << message.getArgAsFloat(i);
-		}else if (message.getArgType(i) == TYPE_STRING){
-			p << message.getArgAsString(i).c_str();
-		}else {
-			throw OscExcInvalidArgumentType();
-		}
-	}
-  p << ::osc::EndMessage;
+    p << ::osc::BeginMessage(message.getAddress().c_str());
+    for (int i = 0; i < message.getNumArgs(); ++i) {
+        if (message.getArgType(i) == TYPE_INT32) {
+            p << message.getArgAsInt32(i);
+        } else if (message.getArgType(i) == TYPE_FLOAT) {
+            p << message.getArgAsFloat(i);
+        } else if (message.getArgType(i) == TYPE_STRING) {
+            p << message.getArgAsString(i).c_str();
+        } else {
+            throw OscExcInvalidArgumentType();
+        }
+    }
+    p << ::osc::EndMessage;
 }

--- a/oscSender.h
+++ b/oscSender.h
@@ -11,25 +11,31 @@
 #define _SENDERH_
 
 struct gdOscSenderSettings {
-  std::string host = "localhost";
-  int port = 0;
+    std::string host = "localhost";
+    int port = 0;
+    int buffersize = 327680;
 };
 
-class gdOscSender{
- public:
-  gdOscSender(){};
-  bool init(std::string host, int port);
-  bool setup(gdOscSenderSettings &settings);
-  void clear();
+class gdOscSender {
+public:
 
-  void sendMessage(gdOscMessage &message);
-  void appendMessage(gdOscMessage &message, osc::OutboundPacketStream &p);
+    gdOscSender() {};
 
+    bool init(std::string host, int port, int buffersize);
 
- private:
-  gdOscSenderSettings settings;
+    bool setup(gdOscSenderSettings &settings);
 
-  std::unique_ptr<UdpTransmitSocket> sendSocket;
+    void clear();
+
+    void sendMessage(gdOscMessage &message);
+
+    void appendMessage(gdOscMessage &message, osc::OutboundPacketStream &p);
+
+private:
+    
+    gdOscSenderSettings settings;
+
+    std::unique_ptr<UdpTransmitSocket> sendSocket;
 };
 
 #endif

--- a/osc_transmitter.cpp
+++ b/osc_transmitter.cpp
@@ -1,59 +1,58 @@
 #include "osc_transmitter.h"
 
 OSCtransmitter::OSCtransmitter() {
-  osc_sender = new gdOscSender();
+    osc_sender = new gdOscSender();
 }
 
 OSCtransmitter::~OSCtransmitter() {
-  if(osc_sender){
-    delete osc_sender;
-  }
+    if (osc_sender) {
+        delete osc_sender;
+    }
 }
 
-
-void OSCtransmitter::init(String host, int port) {
-  std::string _host(utils::gdStringToString(host));
-  osc_sender->init(_host, port );
+void OSCtransmitter::init(String host, int port, int buffersize) {
+    std::string _host(utils::gdStringToString(host));
+    osc_sender->init(_host, port, buffersize);
 }
 
 void OSCtransmitter::testSend() {
-  msg.addStringArg("test");
-  osc_sender->sendMessage(msg);
+    msg.addStringArg("test");
+    osc_sender->sendMessage(msg);
 }
 
 void OSCtransmitter::setAddress(String a) {
-  std::string _addy(utils::gdStringToString(a));
-  msg.setAddress(_addy);
+    std::string _addy(utils::gdStringToString(a));
+    msg.setAddress(_addy);
 }
 
 void OSCtransmitter::appendInt(int m) {
-  msg.addIntArg(m);
+    msg.addIntArg(m);
 }
 
 void OSCtransmitter::appendFloat(float m) {
-  msg.addFloatArg(m);
+    msg.addFloatArg(m);
 }
 
 void OSCtransmitter::appendString(String m) {
-  msg.addStringArg(m);
+    msg.addStringArg(m);
 }
 
 void OSCtransmitter::sendMessage() {
-  osc_sender->sendMessage(msg);
+    osc_sender->sendMessage(msg);
 }
 
 void OSCtransmitter::reset() {
-  msg.clear();
+    msg.clear();
 }
 
 void OSCtransmitter::_bind_methods() {
-  std::cout << "binding should occur...." << std::endl;
-  ClassDB::bind_method(D_METHOD("testSend"), &OSCtransmitter::testSend);
-  ClassDB::bind_method(D_METHOD("init"), &OSCtransmitter::init);
-  ClassDB::bind_method(D_METHOD("setAddress", "a"), &OSCtransmitter::setAddress);
-  ClassDB::bind_method(D_METHOD("appendInt", "m"), &OSCtransmitter::appendInt);
-  ClassDB::bind_method(D_METHOD("appendFloat", "m"), &OSCtransmitter::appendFloat);
-  ClassDB::bind_method(D_METHOD("appendString", "m"), &OSCtransmitter::appendString);
-  ClassDB::bind_method("sendMessage", &OSCtransmitter::sendMessage);
-  ClassDB::bind_method("reset", &OSCtransmitter::reset);
+    std::cout << "binding should occur...." << std::endl;
+    ClassDB::bind_method(D_METHOD("testSend"), &OSCtransmitter::testSend);
+    ClassDB::bind_method(D_METHOD("init"), &OSCtransmitter::init);
+    ClassDB::bind_method(D_METHOD("setAddress", "a"), &OSCtransmitter::setAddress);
+    ClassDB::bind_method(D_METHOD("appendInt", "m"), &OSCtransmitter::appendInt);
+    ClassDB::bind_method(D_METHOD("appendFloat", "m"), &OSCtransmitter::appendFloat);
+    ClassDB::bind_method(D_METHOD("appendString", "m"), &OSCtransmitter::appendString);
+    ClassDB::bind_method("sendMessage", &OSCtransmitter::sendMessage);
+    ClassDB::bind_method("reset", &OSCtransmitter::reset);
 }

--- a/osc_transmitter.h
+++ b/osc_transmitter.h
@@ -10,32 +10,34 @@
 
 #include "oscSender.h"
 
-
 #ifndef GDOSC_H
 #define GDOSC_H
 
-class OSCtransmitter : public Spatial {
-  GDCLASS(OSCtransmitter, Spatial);
+class OSCtransmitter : public Node {
+    GDCLASS(OSCtransmitter, Node);
 
- protected:
-  static void _bind_methods();
+protected:
+    static void _bind_methods();
 
- public:
-  OSCtransmitter();
-  OSCtransmitter(String host, int port);
-  ~OSCtransmitter();
-  void init(String host, int port);
-  void testSend();
-  void setAddress(String a);
-  void appendInt(int m);
-  void sendMessage();
-  void appendFloat(float m);
-  void appendString(String m);
-  void reset();
+public:
 
- private:
-  gdOscSender* osc_sender;
-  gdOscMessage msg;
+    OSCtransmitter();
+    OSCtransmitter(String host, int port);
+    ~OSCtransmitter();
+    void init(String host, int port, int buffersize);
+    void testSend();
+    void setAddress(String a);
+    void sendMessage();
+    void appendInt(int m);
+    void appendFloat(float m);
+    void appendString(String m);
+    void reset();
+
+private:
+
+    gdOscSender* osc_sender;
+    gdOscMessage msg;
+
 };
 
 #endif


### PR DESCRIPTION
- OSCtransmitter now inherits Node and not Spatial (seems more relevant)
- oscSender.init requires to define the buffer size - i didn't found a way to create a init(host,port) and a init(host,port,buffersize) that compiles with gdscript, so the only one accessible now is init(host,port,buffersize)
- script attached to an OSCtransmitter uses the methods of the instance directly (see readme)

i'm waiting for a reply on how to create an icon for the object