### PR TITLE
Clarify under which circumstances signals are emitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ func _ready():
 
 #### using *signals*
 
-If **Emit signal** is enabled, at each [NOTIFICATION_PROCESS](http://docs.godotengine.org/en/3.0/getting_started/step_by_step/scripting_continued.html?highlight=NOTIFICATION_PROCESS), *OSCreceiver* will fire an **osc_message_received** signal.
+If **Emit signal** is enabled, at each [NOTIFICATION_PROCESS](http://docs.godotengine.org/en/3.0/getting_started/step_by_step/scripting_continued.html?highlight=NOTIFICATION_PROCESS), *OSCreceiver* will fire an **osc_message_received** signal. In order for *OSCreceiver* to receive notifications, you need to either add a `_process` method to the instance (even if it is empty) or call `set_process(true)` at an appropriate time, e.g. in the instance's `_ready` method.
 
 To broadcast signals, you have to connect it to *func* of other objects. Let say that your scene is structured as follows:
 
@@ -96,6 +96,7 @@ extends OSCreceiver
 func _ready():
 	connect( "osc_message_received", get_parent().get_node( "TextEdit"), "dump_osc" )
 	connect( "osc_message_received", get_parent().get_node( "MeshObject"), "parse_osc" )
+	set_process(true)
 	pass
 ```
 


### PR DESCRIPTION
`OSCreceiver` does not emit signals, if idle processing is not turned on, i.e. it neither has a `_process` method or calls `set_process(true)`. I added a sentence in the first paragraph of the "using signals" section to clarify that and added a `set_process(true)` call to the following code example.

That this is necessary may be obvious to Godot experts, but as a beginner, I was scratching my head as to why my signal receiver was never called, even though it was connected properly and I was sending OSC messages to the correct destination. Clarifying this in the readme might help to lessen confusion for others.